### PR TITLE
Get the state of the job by exec_id

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -141,6 +141,9 @@ class Rundeck():
         url = '{}/project/{}/executions/running'.format(self.API_URL, project)
         return self.__get(url)
 
+    def execution_state(self, exec_id):
+        url = '{}/execution/{}/state'.format(self.API_URL, exec_id)
+        return self.__get(url)
 
 if __name__ == '__main__':
     from pprint import pprint


### PR DESCRIPTION
Adding a new definition to get the state of a job ("SUCCEEDED" , "FAILED" for instance) by his execution id 