### PR TITLE
Get the log output of the job by exec_id

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -141,6 +141,9 @@ class Rundeck():
         url = '{}/project/{}/executions/running'.format(self.API_URL, project)
         return self.__get(url)
 
+    def execution_output_by_id(self, exec_id):
+        url = '{}/execution/{}/output'.format(self.API_URL, exec_id)
+        return self.__get(url)
 
 if __name__ == '__main__':
     from pprint import pprint


### PR DESCRIPTION
Adding a new definition to get the log output from a job in rundeck by execution id