### PR TITLE
Fix query parameters and add function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .ropeproject/
-*.pyc
+*.py[oc]
 dist/
 build/
 *.spec
 *.egg-info/
+*~

--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 This is a Python REST API client for Rundeck 2.6+
 
+The current version needs Rundeck 3.1+ but many parts still work
+with older versions of Rundeck if you specify a lower `api_version` argument.
+
+## Example
+
+```python
+from pyrundeck import Rundeck
+
+rundeck = Rundeck('http://rundeck-url',
+                  token='sometoken',
+                  api_version=30,  # this is not mandatory
+                 )
+
+run = rundeck.run_job(RUNDECK_JOB_ID, options={'option1': 'foo'})
+
+running_jobs = rundeck.get_executions_for_job(job_id=RUNDECK_JOB_ID, status='running')
+
+for job in running_jobs['executions']:
+  print("%s is running" % job['id'])
+```
+
+A token can be generated in the 'profile' page of Rundeck. Alternatively you
+can login with a username and password.
+
+
 ## See also
 
 - https://github.com/marklap/rundeckrun

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This is a Python REST API client for Rundeck 2.6+
 
-The current version needs Rundeck 3.1+ but many parts still work
-with older versions of Rundeck if you specify a lower `api_version` argument.
+Some function or options required are newer Rundeck version and you need to pass
+a associated `api_version` to the constructor.
 
 ## Example
 
@@ -12,7 +12,7 @@ from pyrundeck import Rundeck
 
 rundeck = Rundeck('http://rundeck-url',
                   token='sometoken',
-                  api_version=30,  # this is not mandatory
+                  api_version=32,  # this is not mandatory, it defaults to 18
                  )
 
 run = rundeck.run_job(RUNDECK_JOB_ID, options={'option1': 'foo'})

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class Rundeck():
     def __init__(self, rundeck_url, token=None, username=None, password=None,
-                 api_version=18, verify=True):
+                 api_version=32, verify=True):
         self.rundeck_url = rundeck_url
         self.API_URL = urljoin(rundeck_url, '/api/{}'.format(api_version))
         self.token = token
@@ -136,6 +136,15 @@ class Rundeck():
             for p in self.list_projects():
                 jobs += self.list_jobs(p['name'])
         return next(job for job in jobs if job['name'] == name)
+
+    def get_running_jobs(self, project, job_id=None):
+        url = '{}/project/{}/executions/running'.format(self.API_URL, project)
+        params = None
+        if job_id is not None:
+            params = {
+                'jobIdFilter': job_id,
+            }
+        return self.__get(url, params=params)
 
     def run_job(self, job_id, args=None, options=None, log_level=None,
                 as_user=None, node_filter=None):

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -48,10 +48,17 @@ class Rundeck():
             'Content-Type': 'application/json',
             'X-Rundeck-Auth-Token': self.token
         }
-        r = requests.request(
-            method, url, cookies=cookies, headers=h, json=params,
-            verify=self.verify
-        )
+        options = {
+            'cookies': cookies,
+            'headers': h,
+            'verify': self.verify,
+        }
+        if method == 'GET':
+            options['params'] = params
+        else:
+            options['json'] = params
+
+        r = requests.request(method, url, **options)
         logger.debug(r.content)
         r.raise_for_status()
         try:

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -33,7 +33,7 @@ class Rundeck():
         p = {'j_username': self.username, 'j_password': self.password}
         r = requests.post(
             url,
-            params=p,
+            data=p,
             verify=self.verify,
             # Disable redirects, otherwise we get redirected twice and need to
             # return r.history[0].cookies['JSESSIONID']

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -155,14 +155,14 @@ class Rundeck():
         job = self.get_job(name)
         return self.run_job(job['id'], *args, **kwargs)
 
-    def get_executions_for_job(self, job_id=None, job_name=None):
+    def get_executions_for_job(self, job_id=None, job_name=None, **kwargs):
         # http://rundeck.org/docs/api/#getting-executions-for-a-job
         if not job_id:
             if not job_name:
                 raise RuntimeError("Either job_name or job_id is required")
             job_id = self.get_job(job_name).get('id')
         url = '{}/job/{}/executions'.format(self.API_URL, job_id)
-        return self.__get(url)
+        return self.__get(url, params=kwargs)
 
     def query_executions(self, project, name=None, group=None, status=None,
                          user=None, recent=None, older=None, begin=None,

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -26,7 +26,9 @@ class Rundeck():
         self.username = username
         self.password = password
         self.verify = verify
-        self.auth_cookie = self.auth()
+        self.auth_cookie = None
+        if self.token is None:
+            self.auth_cookie = self.auth()
 
     def auth(self):
         url = urljoin(self.rundeck_url, '/j_security_check')
@@ -42,7 +44,10 @@ class Rundeck():
 
     def __request(self, method, url, params=None):
         logger.info('{} {} Params: {}'.format(method, url, params))
-        cookies = {'JSESSIONID': self.auth_cookie}
+        cookies = dict()
+        if self.auth_cookie:
+            cookies['JSESSIONID'] = self.auth_cookie
+
         h = {
             'Accept': 'application/json',
             'Content-Type': 'application/json',

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class Rundeck():
     def __init__(self, rundeck_url, token=None, username=None, password=None,
-                 api_version=32, verify=True):
+                 api_version=18, verify=True):
         self.rundeck_url = rundeck_url
         self.API_URL = urljoin(rundeck_url, '/api/{}'.format(api_version))
         self.token = token
@@ -138,6 +138,7 @@ class Rundeck():
         return next(job for job in jobs if job['name'] == name)
 
     def get_running_jobs(self, project, job_id=None):
+        """This requires API version 32"""
         url = '{}/project/{}/executions/running'.format(self.API_URL, project)
         params = None
         if job_id is not None:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyrundeck',
-    version='0.9.8',
+    version='0.9.7',
     description='Python REST API client for Rundeck 2.6+',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pyrundeck',
-    version='0.9.7',
+    version='0.9.8',
     description='Python REST API client for Rundeck 2.6+',
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This builds on top of #23 

It makes that you can actually to a proper GET call with parameters. Until now, they were ignored.

I've also added the `get_running_jobs` which needs api_version 32