### PR TITLE
Fix status filtering

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -50,9 +50,13 @@ class Rundeck():
 
         h = {
             'Accept': 'application/json',
-            'Content-Type': 'application/json',
             'X-Rundeck-Auth-Token': self.token
         }
+        # See https://github.com/rundeck/rundeck/issues/1923
+        if method in ("POST", "PUT"):
+            https://github.com/rundeck/rundeck/issues/1923
+            h['Content-Type']= 'application/json'
+
         options = {
             'cookies': cookies,
             'headers': h,

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -54,7 +54,6 @@ class Rundeck():
         }
         # See https://github.com/rundeck/rundeck/issues/1923
         if method in ("POST", "PUT"):
-            https://github.com/rundeck/rundeck/issues/1923
             h['Content-Type']= 'application/json'
 
         options = {


### PR DESCRIPTION
From https://github.com/rundeck/rundeck/issues/1923:
> I've traced the issue down to the Content-Type header that messes up the whole request (It's not needed for a GET anyway, was there from a previous POST). The output is still a XML, I'll open a different issue for that

There are a few posts saying the same thing: GET requests specifying a
Content-Type header causes the URL parameters to be ignored.