### PR TITLE
Add support for change in create token api

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -99,9 +99,18 @@ class Rundeck(object):
         url = "{}/token/{}".format(self.API_URL, token_id)
         return self.__get(url)
 
-    def create_token(self, user):
+    def create_token(self, user, roles="*", duration=None):
         url = "{}/tokens/{}".format(self.API_URL, user)
-        return self.__post(url)
+        if self.api_version < 19:
+            params = None
+        else:
+            params = {
+                "user": user,
+                "roles": roles,
+                "duration": duration,
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+        return self.__post(url, params=params)
 
     def delete_token(self, token_id):
         url = "{}/token/{}".format(self.API_URL, token_id)

--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -31,6 +31,7 @@ class Rundeck(object):
         self.token = token
         self.username = username
         self.password = password
+        self.api_version = api_version
         self.verify = verify
         self.auth_cookie = None
         if self.token is None:


### PR DESCRIPTION
Change in API for token creation at v19 as per https://docs.rundeck.com/docs/api/rundeck-api.html#create-a-token.
Added api_version attribute explicitly to instance to support coding changing endpoints.