### PR TITLE
Dynamic logging levels

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -31,6 +31,7 @@ class Rundeck(object):
         self.token = token
         self.username = username
         self.password = password
+        self.api_version = api_version
         self.verify = verify
         self.auth_cookie = None
         if self.token is None:
@@ -98,9 +99,18 @@ class Rundeck(object):
         url = "{}/token/{}".format(self.API_URL, token_id)
         return self.__get(url)
 
-    def create_token(self, user):
+    def create_token(self, user, roles="*", duration=None):
         url = "{}/tokens/{}".format(self.API_URL, user)
-        return self.__post(url)
+        if self.api_version < 19:
+            params = None
+        else:
+            params = {
+                "user": user,
+                "roles": roles,
+                "duration": duration,
+            }
+            params = {k: v for k, v in params.items() if v is not None}
+        return self.__post(url, params=params)
 
     def delete_token(self, token_id):
         url = "{}/token/{}".format(self.API_URL, token_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.23.0
+requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.25.0
+requests==2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.24.0
+requests==2.25.0


### PR DESCRIPTION
This is to allow a logging level to be passed when calling methods for the rundeck API to change the level on API calls. Not providing a log level when using the methods will default the log level to the level of the entire script. Any existing external implementations will not be impacted.

Currently there is a single method `run_job()` that takes a parameter `log_level` and does nothing with it. With this pull request it implements any log level changes that are desired.