### PR TITLE
Update rundeck.py

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -10,7 +10,7 @@ import _io
 try:
     # Python 2
     from urlparse import urljoin
-except ModuleNotFoundError:
+except ImportError:
     # Python 3
     from urllib.parse import urljoin
 


### PR DESCRIPTION
Exception except ModuleNotFoundError: replaced by except ImportError: because on python 3.4 the following error was being raised:

Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/pyrundeck/rundeck.py", line 12, in <module>
    from urlparse import urljoin
ImportError: No module named 'urlparse'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.4/site-packages/pyrundeck/__init__.py", line 2, in <module>
    from .rundeck import Rundeck
  File "/usr/lib/python3.4/site-packages/pyrundeck/rundeck.py", line 13, in <module>
    except ModuleNotFoundError:
NameError: name 'ModuleNotFoundError' is not defined