### PR TITLE
add get_project_info

### DIFF
--- a/pyrundeck/rundeck.py
+++ b/pyrundeck/rundeck.py
@@ -157,6 +157,10 @@ class Rundeck(object):
         url = "{}/projects".format(self.API_URL)
         return self.__get(url)
 
+    def get_project_info(self, project_name):
+        url = "{}/project/{}".format(self.API_URL, project_name)
+        return self.__get(url)
+
     def get_project_config(self, project_name):
         url = "{}/project/{}/config".format(self.API_URL, project_name)
         return self.__get(url)


### PR DESCRIPTION
get_project_config only get the config, but more metadata (e.g. name and description) are accessible via get_project_info and I need those.

see https://docs.rundeck.com/docs/api/#getting-project-info